### PR TITLE
feat: add length constraints to Product and ProductImage fields

### DIFF
--- a/src/main/java/com/example/models/Product.java
+++ b/src/main/java/com/example/models/Product.java
@@ -24,9 +24,9 @@ public class Product {
     @NotBlank(message = "The title cannot be empty")
     private String title;
 
-    @Column
+    @Column(length = 600)
     @NotBlank(message = "The description cannot be empty")
-    @Size(min = 20, message = "The description must be more than 20 characters")
+    @Size(min = 20, max = 600, message = "The description must contain at least 20 and no more than 600 characters.")
     private String description;
 
     @Column(precision = 10, scale = 2)

--- a/src/main/java/com/example/models/ProductImage.java
+++ b/src/main/java/com/example/models/ProductImage.java
@@ -23,7 +23,7 @@ public class ProductImage {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column
+    @Column(length = 500)
     private String imageDirectory;
 
     @ManyToOne(fetch = FetchType.LAZY)


### PR DESCRIPTION
- Set maximum length of 500 for ProductImage.imageDirectory.
- Set maximum length of 600 for Product.description with updated validation constraints.